### PR TITLE
Update oref0-pump-loop.sh

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -87,6 +87,8 @@ function timerun {
 
 function fail {
     echo -n "oref0-pump-loop failed. "
+    #acember 4/1/2019
+    grep incorrectly enact/suggested.json && oref0-set-system-clock 2>&3
     if find enact/ -mmin -5 | grep smb-suggested.json >&4 && grep "too old" enact/smb-suggested.json >&4; then
         touch /tmp/pump_loop_completed
         wait_for_bg

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -87,8 +87,9 @@ function timerun {
 
 function fail {
     echo -n "oref0-pump-loop failed. "
-    #acember 4/1/2019
-    grep incorrectly enact/suggested.json && oref0-set-system-clock 2>&3
+    #acember 4/1/2019 
+    #First thing to try if pump loop fails is to set the system clock to match the pump
+    oref0-set-system-clock 2>&3
     if find enact/ -mmin -5 | grep smb-suggested.json >&4 && grep "too old" enact/smb-suggested.json >&4; then
         touch /tmp/pump_loop_completed
         wait_for_bg


### PR DESCRIPTION
Added 
grep incorrectly enact/suggested.json && oref0-set-system-clock 2>&3 
in case of function fail().
This should take care of any clock-based pump loop failures.